### PR TITLE
Seed database with demo data

### DIFF
--- a/database/seeders/BrandSeeder.php
+++ b/database/seeders/BrandSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class BrandSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $brands = ['Nike', 'Adidas', 'Puma', 'Reebok'];
+
+        foreach ($brands as $name) {
+            DB::table('brands')->insert([
+                'name' => $name,
+                'slug' => Str::slug($name),
+                'logo' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class CategorySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $categories = ['Men', 'Women', 'Accessories'];
+
+        foreach ($categories as $name) {
+            DB::table('categories')->insert([
+                'name' => $name,
+                'slug' => Str::slug($name),
+                'parent_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,11 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            UserSeeder::class,
+            CategorySeeder::class,
+            BrandSeeder::class,
+            ProductSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -2,16 +2,64 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class ProductSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
-        //
+        $nike = DB::table('brands')->where('slug', 'nike')->value('id');
+        $adidas = DB::table('brands')->where('slug', 'adidas')->value('id');
+
+        $men = DB::table('categories')->where('slug', 'men')->value('id');
+        $women = DB::table('categories')->where('slug', 'women')->value('id');
+
+        $products = [
+            [
+                'name' => 'Nike Air Zoom Pegasus',
+                'slug' => Str::slug('Nike Air Zoom Pegasus'),
+                'brand_id' => $nike,
+                'category_id' => $men,
+                'short_desc' => 'Popular men\'s running shoes',
+                'description' => 'Comfortable and lightweight for everyday runs.',
+                'price' => 120.00,
+                'sale_price' => 99.99,
+                'stock' => 50,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Adidas Ultraboost',
+                'slug' => Str::slug('Adidas Ultraboost'),
+                'brand_id' => $adidas,
+                'category_id' => $men,
+                'short_desc' => 'Responsive shoes with boost cushioning',
+                'description' => 'A favourite of runners looking for comfort.',
+                'price' => 180.00,
+                'sale_price' => null,
+                'stock' => 30,
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Women Basic T-Shirt',
+                'slug' => Str::slug('Women Basic T-Shirt'),
+                'brand_id' => $nike,
+                'category_id' => $women,
+                'short_desc' => 'Soft cotton t-shirt for everyday wear',
+                'description' => 'Classic fit with breathable material.',
+                'price' => 25.00,
+                'sale_price' => 19.99,
+                'stock' => 100,
+                'is_active' => true,
+            ],
+        ];
+
+        foreach ($products as $product) {
+            DB::table('products')->insert(array_merge($product, [
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]));
+        }
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        User::factory()->count(5)->create();
+    }
+}


### PR DESCRIPTION
## Summary
- add seeders for categories, brands, users and products
- call new seeders from `DatabaseSeeder`

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68455d6c98ec832da2c2ebcf8a30cad1