### PR TITLE
Add Spatie role seeder and admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@
 
 ## About Laravel
 
+### Admin Role Setup
+
+This project uses [Spatie Laravel Permission](https://github.com/spatie/laravel-permission) to handle roles.
+After running the migrations, seed the database to create the default `admin` user:
+
+```bash
+php artisan db:seed --class=RoleSeeder
+```
+
+Log in with `admin@example.com` and password `password` to access routes under `/admin`.
+
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
 
 - [Simple, fast routing engine](https://laravel.com/docs/routing).

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -7,5 +7,8 @@ use Illuminate\Http\Request;
 
 class DashboardController extends Controller
 {
-    //
+    public function index()
+    {
+        return view('admin.dashboard');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\RoleSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,9 +16,6 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(RoleSeeder::class);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Create roles
+        $adminRole = Role::firstOrCreate(['name' => 'admin']);
+        $userRole = Role::firstOrCreate(['name' => 'user']);
+
+        // Create admin user
+        $admin = User::firstOrCreate(
+            ['email' => 'admin@example.com'],
+            [
+                'name' => 'Admin',
+                'password' => Hash::make('password'),
+            ]
+        );
+
+        // Assign role
+        $admin->assignRole($adminRole);
+    }
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold">Admin Dashboard</h1>
+    <p>Welcome to the admin area.</p>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware('auth')->group(function(){
 Route::middleware(['auth','role:admin'])
      ->prefix('admin')->name('admin.')
      ->group(function(){
+        Route::get('/', [Admin\DashboardController::class, 'index'])->name('dashboard');
         Route::resource('products', Admin\ProductController::class);
         Route::resource('order-items', Admin\OrderItemController::class);
         // …và các resource khác tương tự


### PR DESCRIPTION
## Summary
- add HasRoles trait to User
- seed admin role and user
- wire role seeder into DatabaseSeeder
- protect admin routes and add admin dashboard
- document how to seed admin account

## Testing
- `php artisan migrate --force`
- `php artisan db:seed --class=RoleSeeder`
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455d813564832d929c237bed8f4c03