### PR TITLE
Add CRUD logic for controllers

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,28 @@
+# FPT ShopFake Guide
+
+This project is a demo Laravel application for a clothes shop.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   composer install
+   npm install && npm run build
+   ```
+2. Copy `.env.example` to `.env` and configure your database settings.
+3. Run migrations:
+   ```bash
+   php artisan migrate
+   ```
+4. Start the development server:
+   ```bash
+   php artisan serve
+   ```
+
+## Usage
+
+The application exposes RESTful endpoints for managing products, categories, brands and more. Endpoints follow the standard Laravel resource patterns.
+
+Admin routes are prefixed with `/admin` and require authentication with the `admin` role.
+
+

--- a/app/Http/Controllers/Admin/BannerController.php
+++ b/app/Http/Controllers/Admin/BannerController.php
@@ -3,63 +3,26 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Banner;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class BannerController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Banner::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'title' => 'nullable|string',
+            'image' => 'required|string',
+            'link' => 'nullable|url',
+            'position' => 'nullable|string|max:50',
+            'starts_at' => 'nullable|date',
+            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -3,63 +3,23 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Brand;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class BrandController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Brand::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('brands','slug')->ignore($id)],
+            'logo' => 'nullable|string',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -3,63 +3,23 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Category;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class CategoryController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Category::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('categories','slug')->ignore($id)],
+            'parent_id' => 'nullable|exists:categories,id',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/CouponController.php
+++ b/app/Http/Controllers/Admin/CouponController.php
@@ -3,63 +3,24 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Coupon;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class CouponController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Coupon::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'code' => ['required','string','max:100', Rule::unique('coupons','code')->ignore($id)],
+            'discount_type' => ['required', Rule::in(['percent','fixed'])],
+            'discount_value' => 'required|numeric',
+            'expires_at' => 'nullable|date',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/NewsController.php
+++ b/app/Http/Controllers/Admin/NewsController.php
@@ -3,63 +3,25 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\News;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class NewsController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = News::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'title' => 'required|string',
+            'slug' => ['required','string', Rule::unique('news','slug')->ignore($id)],
+            'cover_img' => 'nullable|string',
+            'content' => 'required|string',
+            'author_id' => 'nullable|exists:users,id',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -3,63 +3,23 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Order;
 use Illuminate\Http\Request;
 
 class OrderController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Order::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'user_id' => 'nullable|exists:users,id',
+            'status' => 'required|string|max:50',
+            'total' => 'required|numeric',
+            'payment_method' => 'required|string|max:50',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/OrderItemController.php
+++ b/app/Http/Controllers/Admin/OrderItemController.php
@@ -3,88 +3,23 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
 use App\Models\OrderItem;
 use Illuminate\Http\Request;
 
 class OrderItemController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        $orderItems = OrderItem::all();
-        return view('admin.order_items.index', compact('orderItems'));
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        return view('admin.order_items.create');
-    }
+    protected string $model = OrderItem::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        $data = $request->validate([
-            'order_id' => 'required|integer',
-            'product_id' => 'required|integer',
-            'quantity' => 'required|integer',
+        return [
+            'order_id' => 'required|exists:orders,id',
+            'product_id' => 'required|exists:products,id',
+            'quantity' => 'required|integer|min:1',
             'unit_price' => 'required|numeric',
-        ]);
-
-        OrderItem::create($data);
-
-        return redirect()->route('admin.order-items.index')
-            ->with('success', 'Order item created successfully.');
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(OrderItem $orderItem)
-    {
-        return view('admin.order_items.show', compact('orderItem'));
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(OrderItem $orderItem)
-    {
-        return view('admin.order_items.edit', compact('orderItem'));
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, OrderItem $orderItem)
-    {
-        $data = $request->validate([
-            'order_id' => 'required|integer',
-            'product_id' => 'required|integer',
-            'quantity' => 'required|integer',
-            'unit_price' => 'required|numeric',
-        ]);
-
-        $orderItem->update($data);
-
-        return redirect()->route('admin.order-items.index')
-            ->with('success', 'Order item updated successfully.');
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(OrderItem $orderItem)
-    {
-        $orderItem->delete();
-
-        return redirect()->route('admin.order-items.index')
-            ->with('success', 'Order item deleted successfully.');
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -3,63 +3,30 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Product;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class ProductController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Product::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('products','slug')->ignore($id)],
+            'brand_id' => 'nullable|exists:brands,id',
+            'category_id' => 'nullable|exists:categories,id',
+            'short_desc' => 'nullable|string',
+            'description' => 'nullable|string',
+            'price' => 'required|numeric',
+            'sale_price' => 'nullable|numeric',
+            'stock' => 'required|integer',
+            'is_active' => 'boolean',
+        ];
     }
 }

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -3,9 +3,22 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\Setting;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class SettingController extends Controller
 {
-    //
+    use CrudActions;
+
+    protected string $model = Setting::class;
+
+    protected function rules($id = null)
+    {
+        return [
+            'key' => ['required','string','max:100', Rule::unique('settings','key')->ignore($id)],
+            'value' => 'required|string',
+        ];
+    }
 }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -3,63 +3,23 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\CrudActions;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class UserController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = User::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'email' => ['required','email','max:255', Rule::unique('users','email')->ignore($id)],
+            'password' => $id ? 'sometimes|nullable|string|min:6' : 'required|string|min:6',
+        ];
     }
 }

--- a/app/Http/Controllers/BannerController.php
+++ b/app/Http/Controllers/BannerController.php
@@ -2,63 +2,26 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Banner;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class BannerController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Banner::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'title' => 'nullable|string',
+            'image' => 'required|string',
+            'link' => 'nullable|url',
+            'position' => 'nullable|string|max:50',
+            'starts_at' => 'nullable|date',
+            'ends_at' => 'nullable|date|after_or_equal:starts_at',
+        ];
     }
 }

--- a/app/Http/Controllers/BrandController.php
+++ b/app/Http/Controllers/BrandController.php
@@ -2,63 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Brand;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class BrandController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Brand::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('brands','slug')->ignore($id)],
+            'logo' => 'nullable|string',
+        ];
     }
 }

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -2,63 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class CategoryController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Category::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('categories','slug')->ignore($id)],
+            'parent_id' => 'nullable|exists:categories,id',
+        ];
     }
 }

--- a/app/Http/Controllers/Concerns/CrudActions.php
+++ b/app/Http/Controllers/Concerns/CrudActions.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Http\Request;
+
+trait CrudActions
+{
+    protected string $model;
+
+    protected function modelQuery()
+    {
+        $model = $this->model;
+        return $model::query();
+    }
+
+    public function index()
+    {
+        return response()->json($this->modelQuery()->get());
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate($this->rules());
+        $model = new $this->model;
+        $model->forceFill($data);
+        $model->save();
+        return response()->json($model, 201);
+    }
+
+    public function show($id)
+    {
+        $model = $this->findModel($id);
+        return response()->json($model);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $model = $this->findModel($id);
+        $data = $request->validate($this->rules($model->id));
+        $model->forceFill($data);
+        $model->save();
+        return response()->json($model);
+    }
+
+    public function destroy($id)
+    {
+        $model = $this->findModel($id);
+        $model->delete();
+        return response()->json(['message' => 'Deleted']);
+    }
+
+    protected function findModel($id)
+    {
+        $model = $this->model;
+        return $model::findOrFail($id);
+    }
+
+    protected function rules($id = null)
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/CouponController.php
+++ b/app/Http/Controllers/CouponController.php
@@ -2,63 +2,24 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Coupon;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class CouponController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Coupon::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'code' => ['required','string','max:100', Rule::unique('coupons','code')->ignore($id)],
+            'discount_type' => ['required', Rule::in(['percent','fixed'])],
+            'discount_value' => 'required|numeric',
+            'expires_at' => 'nullable|date',
+        ];
     }
 }

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -2,63 +2,25 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\News;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class NewsController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = News::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'title' => 'required|string',
+            'slug' => ['required','string', Rule::unique('news','slug')->ignore($id)],
+            'cover_img' => 'nullable|string',
+            'content' => 'required|string',
+            'author_id' => 'nullable|exists:users,id',
+        ];
     }
 }

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -2,63 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Order;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class OrderController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Order::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'user_id' => 'nullable|exists:users,id',
+            'status' => 'required|string|max:50',
+            'total' => 'required|numeric',
+            'payment_method' => 'required|string|max:50',
+        ];
     }
 }

--- a/app/Http/Controllers/OrderItemController.php
+++ b/app/Http/Controllers/OrderItemController.php
@@ -2,63 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\OrderItem;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class OrderItemController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = OrderItem::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'order_id' => 'required|exists:orders,id',
+            'product_id' => 'required|exists:products,id',
+            'quantity' => 'required|integer|min:1',
+            'unit_price' => 'required|numeric',
+        ];
     }
 }

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -2,9 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Page;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class PageController extends Controller
 {
-    //
+    use CrudActions;
+
+    protected string $model = Page::class;
+
+    protected function rules($id = null)
+    {
+        return [
+            'slug' => ['required','string', Rule::unique('pages','slug')->ignore($id)],
+            'title' => 'required|string',
+            'content' => 'required|string',
+        ];
+    }
 }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -4,62 +4,28 @@ namespace App\Http\Controllers;
 
 use App\Models\Product;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class ProductController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Product::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(Product $product)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Product $product)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Product $product)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Product $product)
-    {
-        //
+        return [
+            'name' => 'required|string|max:255',
+            'slug' => ['required','string','max:255', Rule::unique('products','slug')->ignore($id)],
+            'brand_id' => 'nullable|exists:brands,id',
+            'category_id' => 'nullable|exists:categories,id',
+            'short_desc' => 'nullable|string',
+            'description' => 'nullable|string',
+            'price' => 'required|numeric',
+            'sale_price' => 'nullable|numeric',
+            'stock' => 'required|integer',
+            'is_active' => 'boolean',
+        ];
     }
 }

--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -2,63 +2,22 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Setting;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Concerns\CrudActions;
 
 class SettingController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
+    use CrudActions;
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
+    protected string $model = Setting::class;
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
+    protected function rules($id = null)
     {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     */
-    public function show(string $id)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(string $id)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
+        return [
+            'key' => ['required','string','max:100', Rule::unique('settings','key')->ignore($id)],
+            'value' => 'required|string',
+        ];
     }
 }


### PR DESCRIPTION
## Summary
- implement `CrudActions` trait for common resource operations
- apply CRUD actions and validation rules across controllers
- document basic setup in `GUIDE.md`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455d69362c832db7dc9ac877ba2ed1