### PR TITLE
Add category UI views and controller methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ After logging in, visit `/admin` to access the admin panel. Only users with the
 ## Documentation
 
 Additional setup information is available in Vietnamese in [docs/HUONG_DAN.md](docs/HUONG_DAN.md). An English translation is provided in [docs/HUONG_DAN_EN.md](docs/HUONG_DAN_EN.md).
+Interface details for the category screens can be found in [docs/UI_DESIGN.md](docs/UI_DESIGN.md).

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -5,19 +5,79 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
-use App\Http\Controllers\Concerns\CrudActions;
 
 class CategoryController extends Controller
 {
-    use CrudActions;
+    /**
+     * Display a listing of categories.
+     */
+    public function index()
+    {
+        $categories = Category::with('parent')->paginate(15);
+        return view('categories.index', compact('categories'));
+    }
 
-    protected string $model = Category::class;
+    /**
+     * Show the form for creating a new category.
+     */
+    public function create()
+    {
+        $parents = Category::pluck('name', 'id');
+        return view('categories.create', compact('parents'));
+    }
 
+    /**
+     * Store a newly created category in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate($this->rules());
+        Category::create($data);
+
+        return redirect()->route('categories.index')
+            ->with('success', __('Category created.'));
+    }
+
+    /**
+     * Show the form for editing the specified category.
+     */
+    public function edit(Category $category)
+    {
+        $parents = Category::where('id', '!=', $category->id)->pluck('name', 'id');
+        return view('categories.edit', compact('category', 'parents'));
+    }
+
+    /**
+     * Update the specified category in storage.
+     */
+    public function update(Request $request, Category $category)
+    {
+        $data = $request->validate($this->rules($category->id));
+        $category->update($data);
+
+        return redirect()->route('categories.index')
+            ->with('success', __('Category updated.'));
+    }
+
+    /**
+     * Remove the specified category from storage.
+     */
+    public function destroy(Category $category)
+    {
+        $category->delete();
+
+        return redirect()->route('categories.index')
+            ->with('success', __('Category deleted.'));
+    }
+
+    /**
+     * Validation rules for store and update actions.
+     */
     protected function rules($id = null)
     {
         return [
             'name' => 'required|string|max:255',
-            'slug' => ['required','string','max:255', Rule::unique('categories','slug')->ignore($id)],
+            'slug' => ['required', 'string', 'max:255', Rule::unique('categories', 'slug')->ignore($id)],
             'parent_id' => 'nullable|exists:categories,id',
         ];
     }

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -1,0 +1,20 @@
+# Interface Overview
+
+This project uses [Tailwind CSS](https://tailwindcss.com/) and the default Laravel Blade layouts to render the user interface.
+
+## Category Management Screens
+
+- **List Categories** (`resources/views/categories/index.blade.php`)
+  - Displays existing categories in a table.
+  - Provides links to edit or delete each record.
+  - Includes a button to add a new category.
+
+- **Create Category** (`resources/views/categories/create.blade.php`)
+  - Simple form to enter `name`, `slug`, and select a parent category.
+  - Uses the built-in Blade components for labels, inputs and buttons.
+
+- **Edit Category** (`resources/views/categories/edit.blade.php`)
+  - Similar to the create form but pre-fills the current values.
+  - Allows changing the parent category or clearing it.
+
+These pages extend `x-app-layout` so navigation and global styles are shared across the site. Images for products or banners should be placed in `public/storage` or an external CDN as desired.

--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -1,0 +1,38 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Category') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('categories.store') }}" class="space-y-6">
+                    @csrf
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name')" required autofocus />
+                        <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                    </div>
+                    <div>
+                        <x-input-label for="slug" :value="__('Slug')" />
+                        <x-text-input id="slug" name="slug" type="text" class="mt-1 block w-full" :value="old('slug')" required />
+                        <x-input-error class="mt-2" :messages="$errors->get('slug')" />
+                    </div>
+                    <div>
+                        <x-input-label for="parent_id" :value="__('Parent Category')" />
+                        <select id="parent_id" name="parent_id" class="mt-1 block w-full border-gray-300 rounded-md">
+                            <option value="">{{ __('None') }}</option>
+                            @foreach($parents as $id => $name)
+                                <option value="{{ $id }}" @selected(old('parent_id') == $id)>{{ $name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error class="mt-2" :messages="$errors->get('parent_id')" />
+                    </div>
+                    <x-primary-button>{{ __('Save') }}</x-primary-button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -1,0 +1,39 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Category') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('categories.update', $category) }}" class="space-y-6">
+                    @csrf
+                    @method('PUT')
+                    <div>
+                        <x-input-label for="name" :value="__('Name')" />
+                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $category->name)" required autofocus />
+                        <x-input-error class="mt-2" :messages="$errors->get('name')" />
+                    </div>
+                    <div>
+                        <x-input-label for="slug" :value="__('Slug')" />
+                        <x-text-input id="slug" name="slug" type="text" class="mt-1 block w-full" :value="old('slug', $category->slug)" required />
+                        <x-input-error class="mt-2" :messages="$errors->get('slug')" />
+                    </div>
+                    <div>
+                        <x-input-label for="parent_id" :value="__('Parent Category')" />
+                        <select id="parent_id" name="parent_id" class="mt-1 block w-full border-gray-300 rounded-md">
+                            <option value="">{{ __('None') }}</option>
+                            @foreach($parents as $id => $name)
+                                <option value="{{ $id }}" @selected(old('parent_id', $category->parent_id) == $id)>{{ $name }}</option>
+                            @endforeach
+                        </select>
+                        <x-input-error class="mt-2" :messages="$errors->get('parent_id')" />
+                    </div>
+                    <x-primary-button>{{ __('Save') }}</x-primary-button>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -1,0 +1,46 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Categories') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="{{ route('categories.create') }}" class="px-4 py-2 bg-indigo-600 text-white rounded">{{ __('Add Category') }}</a>
+            </div>
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Name') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Slug') }}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('Parent') }}</th>
+                            <th class="px-6 py-3"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        @foreach($categories as $category)
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $category->id }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $category->name }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $category->slug }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ optional($category->parent)->name }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                <a href="{{ route('categories.edit', $category) }}" class="text-indigo-600 hover:text-indigo-900 mr-2">{{ __('Edit') }}</a>
+                                <form action="{{ route('categories.destroy', $category) }}" method="POST" class="inline-block" onsubmit="return confirm('Delete?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:text-red-900">{{ __('Delete') }}</button>
+                                </form>
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- implement web views for categories (index, create, edit)
- replace JSON-only `CategoryController` with view-based actions
- document interface details in new `docs/UI_DESIGN.md`
- reference the UI guide from the README

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845698c0044832da5b1da76e92a7b82